### PR TITLE
Add basic tests for core module

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -33,6 +33,10 @@ kotlin {
         commonMain.dependencies {
             implementation(libs.kotlinx.serialization.json)
         }
+
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
     }
 }
 

--- a/core/src/commonTest/kotlin/org/sacada/core/util/ExtensionsTest.kt
+++ b/core/src/commonTest/kotlin/org/sacada/core/util/ExtensionsTest.kt
@@ -1,0 +1,34 @@
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.sacada.core.model.ViewComponent
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ExtensionsTest {
+    private fun componentWithValidation() = ViewComponent(
+        id = "textField",
+        type = "TextField",
+        attributes = buildJsonObject {
+            put("validation", buildJsonObject {
+                put("required", JsonPrimitive(true))
+                put("minLength", JsonPrimitive(3))
+                put("regex", JsonPrimitive("[a-z]+"))
+            })
+        }
+    )
+
+    @Test
+    fun isValid_validValue_returnsTrue() {
+        val component = componentWithValidation()
+        assertTrue(component.isValid("abc"))
+    }
+
+    @Test
+    fun isValid_invalidValue_returnsFalse() {
+        val component = componentWithValidation()
+        assertFalse(component.isValid("ab"))
+        assertFalse(component.isValid("123"))
+        assertFalse(component.isValid(""))
+    }
+}

--- a/core/src/commonTest/kotlin/org/sacada/core/util/JsonParserTest.kt
+++ b/core/src/commonTest/kotlin/org/sacada/core/util/JsonParserTest.kt
@@ -1,0 +1,23 @@
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class JsonParserTest {
+    @Test
+    fun parseScreens_validJson_returnsScreens() {
+        val json = """
+            {"screens": [{"id": "screen1"}]}
+        """.trimIndent()
+        val result = JsonParser.parseScreens(json)
+        assertNotNull(result)
+        assertEquals("screen1", result!!.screens.first().id)
+    }
+
+    @Test
+    fun parseScreens_invalidJson_returnsNull() {
+        val json = "{invalid}"
+        val result = JsonParser.parseScreens(json)
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for JsonParser and validation extensions
- enable kotlin test library for the core `commonTest` source set

## Testing
- `gradle :core:test` *(fails: Plugin com.android.application not found)*

------
https://chatgpt.com/codex/tasks/task_e_684840d0da2c832fb1f4bb19117715fc