### PR TITLE
Add basic unit tests

### DIFF
--- a/core/src/commonTest/kotlin/org/sacada/core/ExtensionsTest.kt
+++ b/core/src/commonTest/kotlin/org/sacada/core/ExtensionsTest.kt
@@ -1,0 +1,53 @@
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.sacada.core.model.ViewComponent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.sacada.core.util.getStringAttribute
+import org.sacada.core.util.getBooleanAttribute
+import org.sacada.core.util.getSubAttributes
+import org.sacada.core.util.isValid
+
+class ExtensionsTest {
+    private val component = ViewComponent(
+        id = "c1",
+        type = "TextField",
+        attributes = buildJsonObject {
+            put("text", JsonPrimitive("hello"))
+            put("enabled", JsonPrimitive(true))
+            put("validation", buildJsonObject {
+                put("required", JsonPrimitive(true))
+                put("minLength", JsonPrimitive(3))
+                put("regex", JsonPrimitive("\\d+"))
+            })
+        }
+    )
+
+    @Test
+    fun testGetStringAttribute() {
+        assertEquals("hello", component.getStringAttribute("text"))
+        assertEquals("", component.getStringAttribute("missing"))
+    }
+
+    @Test
+    fun testGetBooleanAttribute() {
+        assertTrue(component.getBooleanAttribute("enabled"))
+        assertFalse(component.getBooleanAttribute("other"))
+    }
+
+    @Test
+    fun testGetSubAttributes() {
+        val sub = component.getSubAttributes("validation")
+        assertEquals("true", sub?.get("required")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun testIsValid() {
+        assertFalse(component.isValid(""))
+        assertFalse(component.isValid("ab"))
+        assertFalse(component.isValid("abc"))
+        assertTrue(component.isValid("123"))
+    }
+}

--- a/core/src/commonTest/kotlin/org/sacada/core/JsonParserTest.kt
+++ b/core/src/commonTest/kotlin/org/sacada/core/JsonParserTest.kt
@@ -1,0 +1,25 @@
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import org.sacada.core.util.JsonParser
+
+class JsonParserTest {
+    @Test
+    fun parseValidJson() {
+        val json = """
+            {"screens":[{"id":"home","type":"screen","layout":{"id":"layout","type":"column"}}]}
+        """.trimIndent()
+        val result = JsonParser.parseScreens(json)
+        assertNotNull(result)
+        assertEquals(1, result.screens.size)
+        assertEquals("home", result.screens[0].id)
+    }
+
+    @Test
+    fun parseInvalidJsonReturnsNull() {
+        val invalidJson = "{invalid}"
+        val result = JsonParser.parseScreens(invalidJson)
+        assertNull(result)
+    }
+}

--- a/data/src/commonTest/kotlin/org/sacada/data/ui/components/ComponentRegistryTest.kt
+++ b/data/src/commonTest/kotlin/org/sacada/data/ui/components/ComponentRegistryTest.kt
@@ -1,0 +1,66 @@
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.sacada.data.ui.components.ComponentRegistry
+import org.sacada.data.ui.components.ComponentType
+import org.sacada.data.ui.components.box.BoxRenderer
+import org.sacada.data.ui.components.box.BoxGenerator
+import org.sacada.data.ui.components.button.ButtonRenderer
+import org.sacada.data.ui.components.button.ButtonGenerator
+import org.sacada.data.ui.components.bottomBar.BottomBarRenderer
+import org.sacada.data.ui.components.bottomBar.BottomBarGenerator
+import org.sacada.data.ui.components.checkbox.CheckboxRenderer
+import org.sacada.data.ui.components.checkbox.CheckboxGenerator
+import org.sacada.data.ui.components.column.ColumnRenderer
+import org.sacada.data.ui.components.column.ColumnGenerator
+import org.sacada.data.ui.components.floatingActionButton.FloatingActionButtonRenderer
+import org.sacada.data.ui.components.floatingActionButton.FloatingActionButtonGenerator
+import org.sacada.data.ui.components.icon.IconRenderer
+import org.sacada.data.ui.components.icon.IconGenerator
+import org.sacada.data.ui.components.iconButton.IconButtonRenderer
+import org.sacada.data.ui.components.iconButton.IconButtonGenerator
+import org.sacada.data.ui.components.image.ImageRenderer
+import org.sacada.data.ui.components.image.ImageGenerator
+import org.sacada.data.ui.components.row.RowRenderer
+import org.sacada.data.ui.components.row.RowGenerator
+import org.sacada.data.ui.components.text.TextRenderer
+import org.sacada.data.ui.components.text.TextGenerator
+import org.sacada.data.ui.components.textField.TextFieldRenderer
+import org.sacada.data.ui.components.textField.TextFieldGenerator
+import org.sacada.data.ui.components.topBar.TopBarRenderer
+import org.sacada.data.ui.components.topBar.TopBarGenerator
+
+class ComponentRegistryTest {
+    @Test
+    fun testGetRenderer() {
+        assertEquals(BoxRenderer, ComponentRegistry.getRenderer(ComponentType.Box.type))
+        assertEquals(ButtonRenderer, ComponentRegistry.getRenderer(ComponentType.Button.type))
+        assertEquals(BottomBarRenderer, ComponentRegistry.getRenderer(ComponentType.BottomBar.type))
+        assertEquals(CheckboxRenderer, ComponentRegistry.getRenderer(ComponentType.Checkbox.type))
+        assertEquals(ColumnRenderer, ComponentRegistry.getRenderer(ComponentType.Column.type))
+        assertEquals(FloatingActionButtonRenderer, ComponentRegistry.getRenderer(ComponentType.FloatingActionButton.type))
+        assertEquals(IconRenderer, ComponentRegistry.getRenderer(ComponentType.Icon.type))
+        assertEquals(IconButtonRenderer, ComponentRegistry.getRenderer(ComponentType.IconButton.type))
+        assertEquals(ImageRenderer, ComponentRegistry.getRenderer(ComponentType.Image.type))
+        assertEquals(RowRenderer, ComponentRegistry.getRenderer(ComponentType.Row.type))
+        assertEquals(TextRenderer, ComponentRegistry.getRenderer(ComponentType.Text.type))
+        assertEquals(TextFieldRenderer, ComponentRegistry.getRenderer(ComponentType.TextField.type))
+        assertEquals(TopBarRenderer, ComponentRegistry.getRenderer(ComponentType.TopBar.type))
+    }
+
+    @Test
+    fun testGetGenerator() {
+        assertEquals(BoxGenerator, ComponentRegistry.getGenerator(ComponentType.Box.type))
+        assertEquals(ButtonGenerator, ComponentRegistry.getGenerator(ComponentType.Button.type))
+        assertEquals(BottomBarGenerator, ComponentRegistry.getGenerator(ComponentType.BottomBar.type))
+        assertEquals(CheckboxGenerator, ComponentRegistry.getGenerator(ComponentType.Checkbox.type))
+        assertEquals(ColumnGenerator, ComponentRegistry.getGenerator(ComponentType.Column.type))
+        assertEquals(FloatingActionButtonGenerator, ComponentRegistry.getGenerator(ComponentType.FloatingActionButton.type))
+        assertEquals(IconGenerator, ComponentRegistry.getGenerator(ComponentType.Icon.type))
+        assertEquals(IconButtonGenerator, ComponentRegistry.getGenerator(ComponentType.IconButton.type))
+        assertEquals(ImageGenerator, ComponentRegistry.getGenerator(ComponentType.Image.type))
+        assertEquals(RowGenerator, ComponentRegistry.getGenerator(ComponentType.Row.type))
+        assertEquals(TextGenerator, ComponentRegistry.getGenerator(ComponentType.Text.type))
+        assertEquals(TextFieldGenerator, ComponentRegistry.getGenerator(ComponentType.TextField.type))
+        assertEquals(TopBarGenerator, ComponentRegistry.getGenerator(ComponentType.TopBar.type))
+    }
+}

--- a/data/src/commonTest/kotlin/org/sacada/data/util/DataExtensionsTest.kt
+++ b/data/src/commonTest/kotlin/org/sacada/data/util/DataExtensionsTest.kt
@@ -1,0 +1,18 @@
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.sacada.data.util.convertToCamelCase
+import org.sacada.data.util.convertToPascalCase
+import org.sacada.data.util.lowercaseFirstLetter
+
+class DataExtensionsTest {
+    @Test
+    fun testCamelCaseConversion() {
+        assertEquals("MyExample", "MY_EXAMPLE".convertToCamelCase())
+        assertEquals("helloWorld", "hello_world".convertToPascalCase())
+    }
+
+    @Test
+    fun testLowercaseFirstLetter() {
+        assertEquals("example", "Example".lowercaseFirstLetter())
+    }
+}


### PR DESCRIPTION
## Summary
- add JsonParser and ViewComponent extension tests to the core module
- add tests for ComponentRegistry mappings and string helpers in data module

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684b36efa1f8832fad28121fb4c6188b