### PR TITLE
Implement native config provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ cd server-driven-ui
 
 The project retrieves keys from `AppConfigProvider` through build configuration. Add `FIGMA_API_KEY` and `FIGMA_FILE_KEY` to `local.properties`.
 - Android reads these via `AppConfigProvider.android.kt`.
-- Other targets should update `AppConfigProvider.native.kt`.
+- Native targets obtain the values from environment variables through `AppConfigProvider.native.kt`.
 
 3️⃣ **Run the project**
 ```bash

--- a/composeApp/src/nativeMain/kotlin/org/sacada/sdui/config/AppConfigProvider.native.kt
+++ b/composeApp/src/nativeMain/kotlin/org/sacada/sdui/config/AppConfigProvider.native.kt
@@ -1,11 +1,12 @@
 package org.sacada.sdui.config
 
-actual object AppConfigProvider {
-    actual fun getFigmaApiKey(): String {
-        TODO("Not yet implemented")
-    }
+import kotlinx.cinterop.toKString
+import platform.posix.getenv
 
-    actual fun getFigmaFileKey(): String {
-        TODO("Not yet implemented")
-    }
+actual object AppConfigProvider {
+    actual fun getFigmaApiKey(): String =
+        getenv("FIGMA_API_KEY")?.toKString() ?: ""
+
+    actual fun getFigmaFileKey(): String =
+        getenv("FIGMA_FILE_KEY")?.toKString() ?: ""
 }


### PR DESCRIPTION
## Summary
- implement native `AppConfigProvider` using environment variables
- document how the FIGMA keys are read in native targets

## Testing
- `./gradlew test` *(fails: can not find property : FIGMA_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_686da3341318832f9cfc3a6026361758