### PR TITLE
Extend compose templates for top and bottom bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ A **Figma design** converted into JSON.
 
 - Generates explicit Compose code from Figma designs.
 - Uses `RenderScreen.kt` as the template for the base layout of each screen.
-- Also extracts `TopBarRenderer.Render`, `BottomBarRenderer.Render` and
-  `RenderComponent` so updates in these functions propagate to the generated
-  code automatically.
+- Automatically extracts every `Render` method from the component `Renderer`
+  objects as well as `RenderComponent`, so changes to any renderer are reflected
+  in the generated code.
 
 ### 📡 **Figma2SDUI Module**
 - Fetches **Figma API data**.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ A **Figma design** converted into JSON.
 
 - Generates explicit Compose code from Figma designs.
 - Uses `RenderScreen.kt` as the template for the base layout of each screen.
+- Also extracts `TopBarRenderer.Render`, `BottomBarRenderer.Render` and
+  `RenderComponent` so updates in these functions propagate to the generated
+  code automatically.
 
 ### 📡 **Figma2SDUI Module**
 - Fetches **Figma API data**.

--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ A **Figma design** converted into JSON.
 
 - Generates explicit Compose code from Figma designs.
 - Uses `RenderScreen.kt` as the template for the base layout of each screen.
-- Automatically extracts every `Render` method from the component `Renderer`
-  objects as well as `RenderComponent`, so changes to any renderer are reflected
-  in the generated code.
+- Automatically extracts the `Render` function from every component renderer and
+  embeds it as a top-level composable function together with `RenderComponent`,
+  so changes to any renderer are reflected in the generated code.
 
 ### 📡 **Figma2SDUI Module**
 - Fetches **Figma API data**.

--- a/compose-generator/build.gradle.kts
+++ b/compose-generator/build.gradle.kts
@@ -44,9 +44,7 @@ val generateFigmaCompose by tasks.registering(JavaExec::class) {
             .get()
             .asFile.absolutePath,
         project.rootProject.file("data/src/commonMain/kotlin/org/sacada/data/ui/screen/RenderScreen.kt").absolutePath,
-        project.rootProject.file("data/src/commonMain/kotlin/org/sacada/data/ui/components/topBar/TopBarRenderer.kt").absolutePath,
-        project.rootProject.file("data/src/commonMain/kotlin/org/sacada/data/ui/components/bottomBar/BottomBarRenderer.kt").absolutePath,
-        project.rootProject.file("data/src/commonMain/kotlin/org/sacada/data/ui/components/RenderComponent.kt").absolutePath,
+        project.rootProject.file("data/src/commonMain/kotlin/org/sacada/data/ui/components").absolutePath,
     )
 }
 

--- a/compose-generator/build.gradle.kts
+++ b/compose-generator/build.gradle.kts
@@ -44,6 +44,9 @@ val generateFigmaCompose by tasks.registering(JavaExec::class) {
             .get()
             .asFile.absolutePath,
         project.rootProject.file("data/src/commonMain/kotlin/org/sacada/data/ui/screen/RenderScreen.kt").absolutePath,
+        project.rootProject.file("data/src/commonMain/kotlin/org/sacada/data/ui/components/topBar/TopBarRenderer.kt").absolutePath,
+        project.rootProject.file("data/src/commonMain/kotlin/org/sacada/data/ui/components/bottomBar/BottomBarRenderer.kt").absolutePath,
+        project.rootProject.file("data/src/commonMain/kotlin/org/sacada/data/ui/components/RenderComponent.kt").absolutePath,
     )
 }
 

--- a/compose-generator/src/main/kotlin/org/sacada/composegenerator/Generate.kt
+++ b/compose-generator/src/main/kotlin/org/sacada/composegenerator/Generate.kt
@@ -17,13 +17,13 @@ import java.io.File
 
 /**
  * Entry point for generating Compose code from a Figma file.
- * Arguments: apiKey fileKey outputDir renderScreenFile topBarFile bottomBarFile renderComponentFile
+ * Arguments: apiKey fileKey outputDir renderScreenFile componentsDir
  */
 fun main(args: Array<String>) {
-    if (args.size < 7) {
+    if (args.size < 5) {
         println(
             "Usage: generate <apiKey> <fileKey> <outputDir> " +
-                "<renderScreenFile> <topBarFile> <bottomBarFile> <renderComponentFile>"
+                "<renderScreenFile> <componentsDir>"
         )
         return
     }
@@ -31,9 +31,7 @@ fun main(args: Array<String>) {
     val fileKey = args[1]
     val outputDir = File(args[2])
     val renderScreenFile = File(args[3])
-    val topBarFile = File(args[4])
-    val bottomBarFile = File(args[5])
-    val renderComponentFile = File(args[6])
+    val componentsDir = File(args[4])
 
     println("Generating Compose code for Figma in folder: $outputDir")
 
@@ -43,9 +41,7 @@ fun main(args: Array<String>) {
             fileKey,
             outputDir,
             renderScreenFile,
-            topBarFile,
-            bottomBarFile,
-            renderComponentFile,
+            componentsDir,
         )
     }
 }
@@ -55,14 +51,11 @@ suspend fun generateCompose(
     fileKey: String,
     outputDir: File,
     renderScreenFile: File,
-    topBarFile: File,
-    bottomBarFile: File,
-    renderComponentFile: File,
+    componentsDir: File,
 ) {
     val renderScreenTemplate = TemplateExtractor.extractTemplate(renderScreenFile, "RenderScreen")
-    val topBarTemplate = TemplateExtractor.extractTemplate(topBarFile, "Render")
-    val bottomBarTemplate = TemplateExtractor.extractTemplate(bottomBarFile, "Render")
-    val renderComponentTemplate = TemplateExtractor.extractTemplate(renderComponentFile, "RenderComponent")
+    val rendererTemplates = loadRendererTemplates(componentsDir)
+    val renderComponentTemplate = loadRenderComponentTemplate(componentsDir)
     val rootDocument = fetchFigmaData(apiKey, fileKey) ?: return
 
     val json = FigmaJsonConverter(JsonBuilderVisitor()).convert(rootDocument)
@@ -82,7 +75,7 @@ suspend fun generateCompose(
                     Json::class,
                     ViewScreen::class,
                 )
-                .add(helperCode(topBarTemplate, bottomBarTemplate, renderComponentTemplate))
+                .add(helperCode(rendererTemplates, renderComponentTemplate))
                 .add(renderScreenTemplate.body)
                 .build()
 
@@ -102,7 +95,8 @@ suspend fun generateCompose(
                 .addImport("org.sacada.core.model", "ViewScreen")
                 .addImport("androidx.compose.runtime", "Composable")
 
-        val imports = (renderScreenTemplate.imports + topBarTemplate.imports + bottomBarTemplate.imports + renderComponentTemplate.imports).distinct()
+        val rendererImports = rendererTemplates.flatMap { it.info.imports }
+        val imports = (renderScreenTemplate.imports + rendererImports + renderComponentTemplate.imports).distinct()
         imports.forEach { imp ->
             val pkg = imp.substringBeforeLast('.')
             val name = imp.substringAfterLast('.')
@@ -116,32 +110,44 @@ suspend fun generateCompose(
 }
 
 private fun helperCode(
-    topBar: TemplateExtractor.TemplateInfo,
-    bottomBar: TemplateExtractor.TemplateInfo,
+    renderers: List<RendererTemplate>,
     renderComponent: TemplateExtractor.TemplateInfo,
 ): String {
-    val topBarBody = topBar.body.prependIndent("        ")
-    val bottomBarBody = bottomBar.body.prependIndent("        ")
+    val builder = StringBuilder()
+    renderers.forEach { renderer ->
+        val body = renderer.info.body.prependIndent("        ")
+        builder.appendLine("object ${renderer.name} {")
+        builder.appendLine("    @Composable")
+        builder.appendLine("    fun Render(component: ViewComponent, modifier: Modifier? = null) {")
+        builder.appendLine(body)
+        builder.appendLine("    }")
+        builder.appendLine("}")
+        builder.appendLine()
+    }
+
     val renderComponentBody = renderComponent.body.prependIndent("    ")
+    builder.appendLine("@Composable")
+    builder.appendLine("fun RenderComponent(component: ViewComponent, modifier: Modifier? = null) {")
+    builder.appendLine(renderComponentBody)
+    builder.appendLine("}")
 
-    return """
-        object TopBarRenderer {
-            @Composable
-            fun Render(component: ViewComponent, modifier: Modifier? = null) {
-$topBarBody
-            }
-        }
+    return builder.toString().trimIndent()
+}
 
-        object BottomBarRenderer {
-            @Composable
-            fun Render(component: ViewComponent, modifier: Modifier? = null) {
-$bottomBarBody
-            }
-        }
+private data class RendererTemplate(val name: String, val info: TemplateExtractor.TemplateInfo)
 
-        @Composable
-        fun RenderComponent(component: ViewComponent, modifier: Modifier? = null) {
-$renderComponentBody
+private fun loadRendererTemplates(componentsDir: File): List<RendererTemplate> =
+    componentsDir
+        .walkTopDown()
+        .filter { it.isFile && it.name.endsWith("Renderer.kt") }
+        .map { file ->
+            val name = file.nameWithoutExtension
+            val info = TemplateExtractor.extractTemplate(file, "Render")
+            RendererTemplate(name, info)
         }
-    """.trimIndent()
+        .toList()
+
+private fun loadRenderComponentTemplate(componentsDir: File): TemplateExtractor.TemplateInfo {
+    val file = componentsDir.walkTopDown().first { it.name == "RenderComponent.kt" }
+    return TemplateExtractor.extractTemplate(file, "RenderComponent")
 }

--- a/compose-generator/src/main/kotlin/org/sacada/composegenerator/Generate.kt
+++ b/compose-generator/src/main/kotlin/org/sacada/composegenerator/Generate.kt
@@ -75,7 +75,7 @@ suspend fun generateCompose(
                     Json::class,
                     ViewScreen::class,
                 )
-                .add(helperCode(rendererTemplates, renderComponentTemplate))
+                .add(helperCode(rendererTemplates))
                 .add(renderScreenTemplate.body)
                 .build()
 
@@ -111,24 +111,33 @@ suspend fun generateCompose(
 
 private fun helperCode(
     renderers: List<RendererTemplate>,
-    renderComponent: TemplateExtractor.TemplateInfo,
 ): String {
     val builder = StringBuilder()
+
     renderers.forEach { renderer ->
-        val body = renderer.info.body.prependIndent("        ")
-        builder.appendLine("object ${renderer.name} {")
-        builder.appendLine("    @Composable")
-        builder.appendLine("    fun Render(component: ViewComponent, modifier: Modifier? = null) {")
+        val body = renderer.info.body.prependIndent("    ")
+        builder.appendLine("@Composable")
+        builder.appendLine("fun ${renderer.name}(component: ViewComponent, modifier: Modifier? = null) {")
         builder.appendLine(body)
-        builder.appendLine("    }")
         builder.appendLine("}")
         builder.appendLine()
     }
 
-    val renderComponentBody = renderComponent.body.prependIndent("    ")
     builder.appendLine("@Composable")
     builder.appendLine("fun RenderComponent(component: ViewComponent, modifier: Modifier? = null) {")
-    builder.appendLine(renderComponentBody)
+    builder.appendLine("    when (component.type.lowercase()) {")
+    renderers.forEach { renderer ->
+        val type = renderer.name.removeSuffix(\"Renderer\").lowercase()
+        builder.appendLine(\"        \" + \"\"\"$type\"\"\" + \" -> ${renderer.name}(component, modifier)\")
+    }
+    builder.appendLine("        else -> RenderUnsupported(component)")
+    builder.appendLine("    }")
+    builder.appendLine("}")
+    builder.appendLine()
+
+    builder.appendLine("@Composable")
+    builder.appendLine("fun RenderUnsupported(component: ViewComponent) {")
+    builder.appendLine("    Text(text = \"Unsupported component: ${'$'}{component.type}\")")
     builder.appendLine("}")
 
     return builder.toString().trimIndent()

--- a/compose-generator/src/main/kotlin/org/sacada/composegenerator/Generate.kt
+++ b/compose-generator/src/main/kotlin/org/sacada/composegenerator/Generate.kt
@@ -8,6 +8,7 @@ import com.squareup.kotlinpoet.KModifier
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import org.sacada.core.model.ViewScreen
+import org.sacada.core.model.ViewComponent
 import org.sacada.core.util.JsonParser
 import org.sacada.figma2sdui.fetchFigmaData
 import org.sacada.jsonbuilder.converter.FigmaJsonConverter
@@ -16,22 +17,36 @@ import java.io.File
 
 /**
  * Entry point for generating Compose code from a Figma file.
- * Arguments: apiKey fileKey outputDir templateFile
+ * Arguments: apiKey fileKey outputDir renderScreenFile topBarFile bottomBarFile renderComponentFile
  */
 fun main(args: Array<String>) {
-    if (args.size < 4) {
-        println("Usage: generate <apiKey> <fileKey> <outputDir> <templateFile>")
+    if (args.size < 7) {
+        println(
+            "Usage: generate <apiKey> <fileKey> <outputDir> " +
+                "<renderScreenFile> <topBarFile> <bottomBarFile> <renderComponentFile>"
+        )
         return
     }
     val apiKey = args[0]
     val fileKey = args[1]
     val outputDir = File(args[2])
-    val templateFile = File(args[3])
+    val renderScreenFile = File(args[3])
+    val topBarFile = File(args[4])
+    val bottomBarFile = File(args[5])
+    val renderComponentFile = File(args[6])
 
     println("Generating Compose code for Figma in folder: $outputDir")
 
     runBlocking {
-        generateCompose(apiKey, fileKey, outputDir, templateFile)
+        generateCompose(
+            apiKey,
+            fileKey,
+            outputDir,
+            renderScreenFile,
+            topBarFile,
+            bottomBarFile,
+            renderComponentFile,
+        )
     }
 }
 
@@ -39,9 +54,15 @@ suspend fun generateCompose(
     apiKey: String,
     fileKey: String,
     outputDir: File,
-    templateFile: File,
+    renderScreenFile: File,
+    topBarFile: File,
+    bottomBarFile: File,
+    renderComponentFile: File,
 ) {
-    val template = TemplateExtractor.extractTemplate(templateFile, "RenderScreen")
+    val renderScreenTemplate = TemplateExtractor.extractTemplate(renderScreenFile, "RenderScreen")
+    val topBarTemplate = TemplateExtractor.extractTemplate(topBarFile, "Render")
+    val bottomBarTemplate = TemplateExtractor.extractTemplate(bottomBarFile, "Render")
+    val renderComponentTemplate = TemplateExtractor.extractTemplate(renderComponentFile, "RenderComponent")
     val rootDocument = fetchFigmaData(apiKey, fileKey) ?: return
 
     val json = FigmaJsonConverter(JsonBuilderVisitor()).convert(rootDocument)
@@ -60,7 +81,9 @@ suspend fun generateCompose(
                     "val screen = %T.decodeFromString(%T.serializer(), json)",
                     Json::class,
                     ViewScreen::class,
-                ).add(template.body)
+                )
+                .add(helperCode(topBarTemplate, bottomBarTemplate, renderComponentTemplate))
+                .add(renderScreenTemplate.body)
                 .build()
 
         val funSpec =
@@ -79,7 +102,8 @@ suspend fun generateCompose(
                 .addImport("org.sacada.core.model", "ViewScreen")
                 .addImport("androidx.compose.runtime", "Composable")
 
-        template.imports.forEach { imp ->
+        val imports = (renderScreenTemplate.imports + topBarTemplate.imports + bottomBarTemplate.imports + renderComponentTemplate.imports).distinct()
+        imports.forEach { imp ->
             val pkg = imp.substringBeforeLast('.')
             val name = imp.substringAfterLast('.')
             fileSpecBuilder.addImport(pkg, name)
@@ -89,4 +113,35 @@ suspend fun generateCompose(
 
         fileSpec.writeTo(outputDir)
     }
+}
+
+private fun helperCode(
+    topBar: TemplateExtractor.TemplateInfo,
+    bottomBar: TemplateExtractor.TemplateInfo,
+    renderComponent: TemplateExtractor.TemplateInfo,
+): String {
+    val topBarBody = topBar.body.prependIndent("        ")
+    val bottomBarBody = bottomBar.body.prependIndent("        ")
+    val renderComponentBody = renderComponent.body.prependIndent("    ")
+
+    return """
+        object TopBarRenderer {
+            @Composable
+            fun Render(component: ViewComponent, modifier: Modifier? = null) {
+$topBarBody
+            }
+        }
+
+        object BottomBarRenderer {
+            @Composable
+            fun Render(component: ViewComponent, modifier: Modifier? = null) {
+$bottomBarBody
+            }
+        }
+
+        @Composable
+        fun RenderComponent(component: ViewComponent, modifier: Modifier? = null) {
+$renderComponentBody
+        }
+    """.trimIndent()
 }

--- a/compose-generator/src/main/kotlin/org/sacada/composegenerator/Generate.kt
+++ b/compose-generator/src/main/kotlin/org/sacada/composegenerator/Generate.kt
@@ -7,9 +7,10 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
-import org.sacada.core.model.ViewScreen
 import org.sacada.core.model.ViewComponent
+import org.sacada.core.model.ViewScreen
 import org.sacada.core.util.JsonParser
+import org.sacada.data.ui.components.ComponentRegistry
 import org.sacada.figma2sdui.fetchFigmaData
 import org.sacada.jsonbuilder.converter.FigmaJsonConverter
 import org.sacada.jsonbuilder.generator.JsonBuilderVisitor
@@ -23,7 +24,7 @@ fun main(args: Array<String>) {
     if (args.size < 5) {
         println(
             "Usage: generate <apiKey> <fileKey> <outputDir> " +
-                "<renderScreenFile> <componentsDir>"
+                "<renderScreenFile> <componentsDir>",
         )
         return
     }
@@ -66,6 +67,9 @@ suspend fun generateCompose(
 
         val screenJson = Json.encodeToString(screen)
 
+        // Processa componentes TopBar e gera código específico
+        processTopBarComponents(screen, outputDir)
+
         val codeBlock =
             CodeBlock
                 .builder()
@@ -74,8 +78,7 @@ suspend fun generateCompose(
                     "val screen = %T.decodeFromString(%T.serializer(), json)",
                     Json::class,
                     ViewScreen::class,
-                )
-                .add(helperCode(rendererTemplates))
+                ).add(helperCode(rendererTemplates))
                 .add(renderScreenTemplate.body)
                 .build()
 
@@ -109,9 +112,7 @@ suspend fun generateCompose(
     }
 }
 
-private fun helperCode(
-    renderers: List<RendererTemplate>,
-): String {
+private fun helperCode(renderers: List<RendererTemplate>): String {
     val builder = StringBuilder()
 
     renderers.forEach { renderer ->
@@ -127,23 +128,36 @@ private fun helperCode(
     builder.appendLine("fun RenderComponent(component: ViewComponent, modifier: Modifier? = null) {")
     builder.appendLine("    when (component.type.lowercase()) {")
     renderers.forEach { renderer ->
-        val type = renderer.name.removeSuffix(\"Renderer\").lowercase()
-        builder.appendLine(\"        \" + \"\"\"$type\"\"\" + \" -> ${renderer.name}(component, modifier)\")
+        val type = renderer.name.removeSuffix("Renderer").lowercase()
+        builder.appendLine("        \"$type\" -> ${renderer.name}(component, modifier)")
     }
     builder.appendLine("        else -> RenderUnsupported(component)")
     builder.appendLine("    }")
     builder.appendLine("}")
     builder.appendLine()
 
+    // Adiciona função para gerar código usando CodeGenerator
+    builder.appendLine("fun generateComponentCode(component: ViewComponent): String {")
+    builder.appendLine("    return try {")
+    builder.appendLine("        ComponentRegistry.getCodeGenerator(component.type).generateCode(component)")
+    builder.appendLine("    } catch (e: Exception) {")
+    builder.appendLine("        \"// Code generation not supported for component type: \${component.type}\"")
+    builder.appendLine("    }")
+    builder.appendLine("}")
+    builder.appendLine()
+
     builder.appendLine("@Composable")
     builder.appendLine("fun RenderUnsupported(component: ViewComponent) {")
-    builder.appendLine("    Text(text = \"Unsupported component: ${'$'}{component.type}\")")
+    builder.appendLine("    Text(text = \"Unsupported component: \${component.type}\")")
     builder.appendLine("}")
 
     return builder.toString().trimIndent()
 }
 
-private data class RendererTemplate(val name: String, val info: TemplateExtractor.TemplateInfo)
+private data class RendererTemplate(
+    val name: String,
+    val info: TemplateExtractor.TemplateInfo,
+)
 
 private fun loadRendererTemplates(componentsDir: File): List<RendererTemplate> =
     componentsDir
@@ -153,10 +167,42 @@ private fun loadRendererTemplates(componentsDir: File): List<RendererTemplate> =
             val name = file.nameWithoutExtension
             val info = TemplateExtractor.extractTemplate(file, "Render")
             RendererTemplate(name, info)
-        }
-        .toList()
+        }.toList()
 
 private fun loadRenderComponentTemplate(componentsDir: File): TemplateExtractor.TemplateInfo {
     val file = componentsDir.walkTopDown().first { it.name == "RenderComponent.kt" }
     return TemplateExtractor.extractTemplate(file, "RenderComponent")
+}
+
+private fun processTopBarComponents(
+    screen: ViewScreen,
+    outputDir: File,
+) {
+    fun processComponent(component: ViewComponent) {
+        if (component.type.lowercase() == "topbar") {
+            try {
+                val codeGenerator = ComponentRegistry.getCodeGenerator("topbar")
+                val generatedCode = codeGenerator.generateCode(component)
+
+                // Salva o código gerado em um arquivo separado
+                val fileName = "TopBar_${component.id}.kt"
+                val file = File(outputDir, fileName)
+                file.writeText(generatedCode)
+
+                println("Generated TopBar code for component ${component.id} -> $fileName")
+            } catch (e: Exception) {
+                println("Failed to generate code for TopBar component ${component.id}: ${e.message}")
+            }
+        }
+
+        // Processa recursivamente os componentes filhos
+        component.children.forEach { child ->
+            processComponent(child)
+        }
+    }
+
+    // Processa os componentes da tela conforme a estrutura do ViewScreen
+    screen.topBar?.let { processComponent(it) }
+    screen.bottomBar?.let { processComponent(it) }
+    screen.layout?.let { processComponent(it) }
 }

--- a/compose-generator/src/main/kotlin/org/sacada/composegenerator/TemplateExtractor.kt
+++ b/compose-generator/src/main/kotlin/org/sacada/composegenerator/TemplateExtractor.kt
@@ -8,6 +8,8 @@ import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import java.io.File
 
 /** Utility to extract template composable source from a Kotlin file. */
@@ -41,15 +43,19 @@ object TemplateExtractor {
             val psiFactory = KtPsiFactory(project, false)
             val ktFile = psiFactory.createFile(file.name, file.readText())
             val imports = ktFile.importDirectives.mapNotNull { it.importPath?.pathStr }
-            val function =
-                ktFile.declarations
-                    .filterIsInstance<KtNamedFunction>()
-                    .firstOrNull { it.name == functionName }
-                    ?: error("Function $functionName not found in ${file.path}")
+            val function = findFunctionRecursively(ktFile, functionName)
+                ?: error("Function $functionName not found in ${file.path}")
             val body = function.bodyExpression?.text ?: ""
             TemplateInfo(imports, body.trim())
         } finally {
             Disposer.dispose(disposable)
         }
+    }
+
+    private fun findFunctionRecursively(
+        element: KtElement,
+        name: String,
+    ): KtNamedFunction? {
+        return element.collectDescendantsOfType<KtNamedFunction> { it.name == name }.firstOrNull()
     }
 }

--- a/core/src/commonMain/kotlin/org/sacada/core/util/Extensions.kt
+++ b/core/src/commonMain/kotlin/org/sacada/core/util/Extensions.kt
@@ -27,6 +27,15 @@ fun ViewComponent.getBooleanAttribute(key: String): Boolean =
         }
     } ?: false
 
+fun ViewComponent.getIntAttribute(key: String): Int =
+    attributes[key]?.let {
+        if (it is JsonPrimitive) {
+            it.intOrNull
+        } else {
+            it.toString().toIntOrNull()
+        }
+    } ?: 0
+
 fun ViewComponent.getSubAttributes(key: String): Map<String, JsonElement>? = attributes[key]?.jsonObject?.toMap()
 
 fun ViewComponent.isValid(value: String): Boolean {
@@ -39,7 +48,5 @@ fun ViewComponent.isValid(value: String): Boolean {
     if (minLength != null && value.length < minLength) return false
 
     val regex = validationAttributes["regex"]?.jsonPrimitive?.contentOrNull
-    if (regex != null && !Regex(regex).matches(value)) return false
-
-    return true
+    return !(regex != null && !Regex(regex).matches(value))
 }

--- a/data/readme.md
+++ b/data/readme.md
@@ -126,6 +126,9 @@ fun RenderScreen(screen: ViewScreen) {
 > generator runs, it parses this file and injects its structure directly into the generated Compose
 > functions. Any structural change made here (for example adding a `FloatingActionButton`) will
 > automatically appear in the generated screens without further modifications.
+> The same mechanism is applied to `TopBarRenderer.Render`, `BottomBarRenderer.Render`
+> and `RenderComponent`, ensuring any updates to these rendering functions are
+> reflected in the generated code.
 
 ---
 

--- a/data/readme.md
+++ b/data/readme.md
@@ -126,9 +126,9 @@ fun RenderScreen(screen: ViewScreen) {
 > generator runs, it parses this file and injects its structure directly into the generated Compose
 > functions. Any structural change made here (for example adding a `FloatingActionButton`) will
 > automatically appear in the generated screens without further modifications.
-> The generator also scans the `components` folder and extracts every renderer's
-> `Render` method along with `RenderComponent`. This means any update to a
-> renderer automatically propagates to the generated code.
+> The generator also scans the `components` folder and extracts each renderer's `Render`
+> function, embedding it as a top-level composable together with `RenderComponent`. This means any
+> update to a renderer automatically propagates to the generated code.
 
 ---
 

--- a/data/readme.md
+++ b/data/readme.md
@@ -126,9 +126,9 @@ fun RenderScreen(screen: ViewScreen) {
 > generator runs, it parses this file and injects its structure directly into the generated Compose
 > functions. Any structural change made here (for example adding a `FloatingActionButton`) will
 > automatically appear in the generated screens without further modifications.
-> The same mechanism is applied to `TopBarRenderer.Render`, `BottomBarRenderer.Render`
-> and `RenderComponent`, ensuring any updates to these rendering functions are
-> reflected in the generated code.
+> The generator also scans the `components` folder and extracts every renderer's
+> `Render` method along with `RenderComponent`. This means any update to a
+> renderer automatically propagates to the generated code.
 
 ---
 

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/Component.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/Component.kt
@@ -24,4 +24,8 @@ interface Component {
             performAction: ((MutableMap<String, JsonElement>) -> Unit)? = null,
         ): JsonObject
     }
+
+    interface CodeGenerator {
+        fun generateCode(component: ViewComponent): String
+    }
 }

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/ComponentRegistry.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/ComponentRegistry.kt
@@ -30,6 +30,7 @@ import org.sacada.data.ui.components.text.TextGenerator
 import org.sacada.data.ui.components.text.TextRenderer
 import org.sacada.data.ui.components.textField.TextFieldGenerator
 import org.sacada.data.ui.components.textField.TextFieldRenderer
+import org.sacada.data.ui.components.topBar.TopBarCodeGenerator
 import org.sacada.data.ui.components.topBar.TopBarGenerator
 import org.sacada.data.ui.components.topBar.TopBarRenderer
 
@@ -72,5 +73,11 @@ object ComponentRegistry {
             ComponentType.Text -> TextGenerator
             ComponentType.TextField -> TextFieldGenerator
             ComponentType.TopBar -> TopBarGenerator
+        }
+
+    fun getCodeGenerator(type: String): Component.CodeGenerator =
+        when (ComponentType.fromType(type)) {
+            ComponentType.TopBar -> TopBarCodeGenerator
+            else -> error("Code generation not supported for component type: $type")
         }
 }

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/topBar/TopBar.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/topBar/TopBar.kt
@@ -1,0 +1,171 @@
+package org.sacada.data.ui.components.topBar
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MediumTopAppBar
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarColors
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarDefaults.topAppBarColors
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import kotlinx.serialization.json.JsonPrimitive
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.sacada.core.model.ViewComponent
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TopBar(
+    appBarType: String,
+    barTitle: String,
+    navigationIcon: @Composable () -> Unit,
+    actions: @Composable RowScope.() -> Unit,
+    scrollBehaviorType: String,
+    paddingModifier: Modifier = Modifier,
+    modifier: Modifier? = null,
+) {
+    val scrollBehavior = resolveScrollBehavior(scrollBehaviorType)
+    val appBar = remember { resolveAppBarType(appBarType) }
+    val title = createTitleComposable(barTitle)
+
+    val colors =
+        topAppBarColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            titleContentColor = MaterialTheme.colorScheme.primary,
+        )
+
+    appBar(
+        title,
+        navigationIcon,
+        actions,
+        colors,
+        scrollBehavior,
+        modifier?.then(paddingModifier) ?: paddingModifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun resolveScrollBehavior(scrollBehaviorType: String?): TopAppBarScrollBehavior? {
+    val appBarState = rememberTopAppBarState()
+    return when (scrollBehaviorType) {
+        "enterAlways" -> TopAppBarDefaults.enterAlwaysScrollBehavior(appBarState)
+        "exitUntilCollapsed" -> TopAppBarDefaults.exitUntilCollapsedScrollBehavior(appBarState)
+        "pinned" -> TopAppBarDefaults.pinnedScrollBehavior(appBarState)
+        else -> null
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+private fun resolveAppBarType(
+    type: String,
+): @Composable (
+    title: @Composable () -> Unit,
+    navigationIcon: @Composable () -> Unit,
+    actions: @Composable RowScope.() -> Unit,
+    colors: TopAppBarColors,
+    scrollBehavior: TopAppBarScrollBehavior?,
+    modifier: Modifier,
+) -> Unit =
+    when (type) {
+        "large" -> { title, navigationIcon, actions, colors, scrollBehavior, modifier ->
+            LargeTopAppBar(
+                title = title,
+                navigationIcon = navigationIcon,
+                actions = actions,
+                colors = colors,
+                scrollBehavior = scrollBehavior,
+                modifier = modifier,
+            )
+        }
+
+        "medium" -> { title, navigationIcon, actions, colors, scrollBehavior, modifier ->
+            MediumTopAppBar(
+                title = title,
+                navigationIcon = navigationIcon,
+                actions = actions,
+                colors = colors,
+                scrollBehavior = scrollBehavior,
+                modifier = modifier,
+            )
+        }
+
+        "center", "Small centered" -> {
+            title,
+            navigationIcon,
+            actions,
+            colors,
+            scrollBehavior,
+            modifier,
+            ->
+            CenterAlignedTopAppBar(
+                title = title,
+                navigationIcon = navigationIcon,
+                actions = actions,
+                colors = colors,
+                scrollBehavior = scrollBehavior,
+                modifier = modifier,
+            )
+        }
+
+        else -> { title, navigationIcon, actions, colors, scrollBehavior, modifier ->
+            TopAppBar(
+                title = title,
+                navigationIcon = navigationIcon,
+                actions = actions,
+                colors = colors,
+                scrollBehavior = scrollBehavior,
+                modifier = modifier,
+            )
+        }
+    }
+
+@Composable
+private fun createTitleComposable(barTitle: String): @Composable () -> Unit =
+    {
+        Text(
+            text = barTitle,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+
+@Preview()
+@Composable
+fun PreviewRenderTopBar() {
+    val sampleComponent =
+        ViewComponent(
+            type = "center",
+            attributes =
+                mapOf(
+                    "title" to JsonPrimitive("Sample Top Bar"),
+                    "scrollBehavior" to JsonPrimitive("enterAlways"),
+                ),
+            children =
+                listOf(
+                    ViewComponent(
+                        type = "navigationIcon",
+                        attributes =
+                            mapOf(
+                                "iconName" to JsonPrimitive("arrow_back"),
+                            ),
+                    ),
+                    ViewComponent(
+                        type = "Action",
+                        attributes =
+                            mapOf(
+                                "iconName" to JsonPrimitive("menu"),
+                            ),
+                    ),
+                ),
+        )
+    TopBarRenderer.Render(component = sampleComponent)
+}

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/topBar/TopBarCodeGenerator.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/topBar/TopBarCodeGenerator.kt
@@ -1,8 +1,6 @@
 package org.sacada.data.ui.components.topBar
 
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.sacada.annotation.RegisterComponent
@@ -10,17 +8,10 @@ import org.sacada.core.model.ViewComponent
 import org.sacada.core.util.getIntAttribute
 import org.sacada.core.util.getStringAttribute
 import org.sacada.data.ui.components.Component
-import org.sacada.data.ui.components.box.BoxRenderer
-import org.sacada.data.util.createActions
 
 @RegisterComponent
-object TopBarRenderer : Component.Renderer {
-    @OptIn(ExperimentalMaterial3Api::class)
-    @Composable
-    override fun Render(
-        component: ViewComponent,
-        modifier: Modifier?,
-    ) {
+object TopBarCodeGenerator : Component.CodeGenerator {
+    override fun generateCode(component: ViewComponent): String {
         val scrollBehaviorType = component.getStringAttribute("scrollBehavior")
         val appBarType = component.getStringAttribute("topBarType")
         val barTitle = component.getStringAttribute("title")
@@ -28,9 +19,6 @@ object TopBarRenderer : Component.Renderer {
         val paddingRight = component.getIntAttribute("paddingRight")
         val paddingTop = component.getIntAttribute("paddingTop")
         val paddingBottom = component.getIntAttribute("paddingBottom")
-
-        val navigationIcon = createNavigationIconComposable(component)
-        val actions = component.createActions()
 
         val paddingModifier =
             Modifier.padding(
@@ -40,21 +28,18 @@ object TopBarRenderer : Component.Renderer {
                 bottom = paddingBottom.dp,
             )
 
-        TopBar(
-            appBarType = appBarType,
-            barTitle = barTitle,
-            navigationIcon = navigationIcon,
-            scrollBehaviorType = scrollBehaviorType,
-            actions = actions,
-            paddingModifier = paddingModifier,
-        )
-    }
+        val code = StringBuilder()
+        code.appendLine("// Code generated for TopBar (id=${component.id})")
+        code.append("TopBar(")
 
-    @Composable
-    private fun createNavigationIconComposable(component: ViewComponent): @Composable () -> Unit =
-        {
-            component.children.find { it.type == "navigationIcon" }?.let {
-                BoxRenderer.Render(it)
-            }
-        }
+        code.appendLine("component = $component },")
+        code.appendLine("scrollBehaviorType = $scrollBehaviorType },")
+        code.appendLine("appBarType = $appBarType },")
+        code.appendLine("barTitle = $barTitle },")
+        code.appendLine("paddingModifier = $paddingModifier },")
+
+        code.appendLine(")")
+
+        return code.toString()
+    }
 }


### PR DESCRIPTION
## Summary
- expand compose-generator to load template code for TopBarRenderer.Render, BottomBarRenderer.Render and RenderComponent
- adjust TemplateExtractor to search functions recursively
- update Gradle task with additional template file arguments
- document new template behaviour in README files

## Testing
- `./gradlew --version`
- `./gradlew build` *(fails: SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a2367b7c0832f98b749e1bd7f5d9b