### PR TITLE
Introduce blueprint layer

### DIFF
--- a/compose-generator/src/main/kotlin/org/sacada/composegenerator/Generate.kt
+++ b/compose-generator/src/main/kotlin/org/sacada/composegenerator/Generate.kt
@@ -8,8 +8,8 @@ import com.squareup.kotlinpoet.KModifier
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import org.sacada.core.model.ViewScreen
-import org.sacada.core.model.ViewComponent
 import org.sacada.core.util.JsonParser
+import org.sacada.data.ui.screen.RenderScreen
 import org.sacada.figma2sdui.fetchFigmaData
 import org.sacada.jsonbuilder.converter.FigmaJsonConverter
 import org.sacada.jsonbuilder.generator.JsonBuilderVisitor
@@ -53,9 +53,7 @@ suspend fun generateCompose(
     renderScreenFile: File,
     componentsDir: File,
 ) {
-    val renderScreenTemplate = TemplateExtractor.extractTemplate(renderScreenFile, "RenderScreen")
-    val rendererTemplates = loadRendererTemplates(componentsDir)
-    val renderComponentTemplate = loadRenderComponentTemplate(componentsDir)
+    // RenderScreen composable from runtime module
     val rootDocument = fetchFigmaData(apiKey, fileKey) ?: return
 
     val json = FigmaJsonConverter(JsonBuilderVisitor()).convert(rootDocument)
@@ -75,8 +73,7 @@ suspend fun generateCompose(
                     Json::class,
                     ViewScreen::class,
                 )
-                .add(helperCode(rendererTemplates))
-                .add(renderScreenTemplate.body)
+                .addStatement("RenderScreen(screen)")
                 .build()
 
         val funSpec =
@@ -95,13 +92,7 @@ suspend fun generateCompose(
                 .addImport("org.sacada.core.model", "ViewScreen")
                 .addImport("androidx.compose.runtime", "Composable")
 
-        val rendererImports = rendererTemplates.flatMap { it.info.imports }
-        val imports = (renderScreenTemplate.imports + rendererImports + renderComponentTemplate.imports).distinct()
-        imports.forEach { imp ->
-            val pkg = imp.substringBeforeLast('.')
-            val name = imp.substringAfterLast('.')
-            fileSpecBuilder.addImport(pkg, name)
-        }
+        fileSpecBuilder.addImport("org.sacada.data.ui.screen", "RenderScreen")
 
         val fileSpec = fileSpecBuilder.build()
 
@@ -109,54 +100,3 @@ suspend fun generateCompose(
     }
 }
 
-private fun helperCode(
-    renderers: List<RendererTemplate>,
-): String {
-    val builder = StringBuilder()
-
-    renderers.forEach { renderer ->
-        val body = renderer.info.body.prependIndent("    ")
-        builder.appendLine("@Composable")
-        builder.appendLine("fun ${renderer.name}(component: ViewComponent, modifier: Modifier? = null) {")
-        builder.appendLine(body)
-        builder.appendLine("}")
-        builder.appendLine()
-    }
-
-    builder.appendLine("@Composable")
-    builder.appendLine("fun RenderComponent(component: ViewComponent, modifier: Modifier? = null) {")
-    builder.appendLine("    when (component.type.lowercase()) {")
-    renderers.forEach { renderer ->
-        val type = renderer.name.removeSuffix(\"Renderer\").lowercase()
-        builder.appendLine(\"        \" + \"\"\"$type\"\"\" + \" -> ${renderer.name}(component, modifier)\")
-    }
-    builder.appendLine("        else -> RenderUnsupported(component)")
-    builder.appendLine("    }")
-    builder.appendLine("}")
-    builder.appendLine()
-
-    builder.appendLine("@Composable")
-    builder.appendLine("fun RenderUnsupported(component: ViewComponent) {")
-    builder.appendLine("    Text(text = \"Unsupported component: ${'$'}{component.type}\")")
-    builder.appendLine("}")
-
-    return builder.toString().trimIndent()
-}
-
-private data class RendererTemplate(val name: String, val info: TemplateExtractor.TemplateInfo)
-
-private fun loadRendererTemplates(componentsDir: File): List<RendererTemplate> =
-    componentsDir
-        .walkTopDown()
-        .filter { it.isFile && it.name.endsWith("Renderer.kt") }
-        .map { file ->
-            val name = file.nameWithoutExtension
-            val info = TemplateExtractor.extractTemplate(file, "Render")
-            RendererTemplate(name, info)
-        }
-        .toList()
-
-private fun loadRenderComponentTemplate(componentsDir: File): TemplateExtractor.TemplateInfo {
-    val file = componentsDir.walkTopDown().first { it.name == "RenderComponent.kt" }
-    return TemplateExtractor.extractTemplate(file, "RenderComponent")
-}

--- a/core/src/commonMain/kotlin/org/sacada/core/blueprint/Blueprint.kt
+++ b/core/src/commonMain/kotlin/org/sacada/core/blueprint/Blueprint.kt
@@ -1,0 +1,13 @@
+package org.sacada.core.blueprint
+
+import org.sacada.core.model.ViewComponent
+
+sealed interface Blueprint {
+    val id: String
+}
+
+/** Generic blueprint used when no specific blueprint exists. */
+data class GenericBlueprint(
+    override val id: String,
+    val component: ViewComponent
+) : Blueprint

--- a/core/src/commonMain/kotlin/org/sacada/core/blueprint/BoxBlueprint.kt
+++ b/core/src/commonMain/kotlin/org/sacada/core/blueprint/BoxBlueprint.kt
@@ -1,0 +1,33 @@
+package org.sacada.core.blueprint
+
+import org.sacada.core.model.Action
+import org.sacada.core.model.ViewComponent
+import org.sacada.core.util.getStringAttribute
+
+data class BoxBlueprint(
+    override val id: String,
+    val paddingLeft: Int,
+    val paddingRight: Int,
+    val paddingTop: Int,
+    val paddingBottom: Int,
+    val height: Float,
+    val width: Float,
+    val action: Action?,
+    val children: List<ViewComponent>
+) : Blueprint {
+    companion object {
+        fun from(component: ViewComponent): BoxBlueprint {
+            return BoxBlueprint(
+                id = component.id,
+                paddingLeft = component.getStringAttribute("paddingLeft").toIntOrNull() ?: 0,
+                paddingRight = component.getStringAttribute("paddingRight").toIntOrNull() ?: 0,
+                paddingTop = component.getStringAttribute("paddingTop").toIntOrNull() ?: 0,
+                paddingBottom = component.getStringAttribute("paddingBottom").toIntOrNull() ?: 0,
+                height = component.getStringAttribute("height").toFloatOrNull() ?: 0f,
+                width = component.getStringAttribute("width").toFloatOrNull() ?: 0f,
+                action = component.action,
+                children = component.children
+            )
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/org/sacada/core/blueprint/ButtonBlueprint.kt
+++ b/core/src/commonMain/kotlin/org/sacada/core/blueprint/ButtonBlueprint.kt
@@ -1,0 +1,22 @@
+package org.sacada.core.blueprint
+
+import org.sacada.core.model.Action
+import org.sacada.core.model.ViewComponent
+
+/**
+ * Blueprint for a Button component.
+ */
+data class ButtonBlueprint(
+    override val id: String,
+    val action: Action?,
+    val children: List<ViewComponent>
+) : Blueprint {
+    companion object {
+        fun from(component: ViewComponent): ButtonBlueprint =
+            ButtonBlueprint(
+                id = component.id,
+                action = component.action,
+                children = component.children
+            )
+    }
+}

--- a/core/src/commonMain/kotlin/org/sacada/core/blueprint/TextBlueprint.kt
+++ b/core/src/commonMain/kotlin/org/sacada/core/blueprint/TextBlueprint.kt
@@ -1,0 +1,30 @@
+package org.sacada.core.blueprint
+
+import kotlinx.serialization.json.jsonPrimitive
+import org.sacada.core.model.ViewComponent
+import org.sacada.core.util.getStringAttribute
+import org.sacada.core.util.getSubAttributes
+
+/** Blueprint for Text component. */
+data class TextBlueprint(
+    override val id: String,
+    val content: String,
+    val styleType: String?,
+    val paddingLeft: Int,
+    val paddingRight: Int,
+    val paddingTop: Int,
+    val paddingBottom: Int,
+) : Blueprint {
+    companion object {
+        fun from(component: ViewComponent): TextBlueprint =
+            TextBlueprint(
+                id = component.id,
+                content = component.getStringAttribute("content"),
+                styleType = component.getSubAttributes("style")?.get("type")?.jsonPrimitive?.contentOrNull,
+                paddingLeft = component.getStringAttribute("paddingLeft").toIntOrNull() ?: 0,
+                paddingRight = component.getStringAttribute("paddingRight").toIntOrNull() ?: 0,
+                paddingTop = component.getStringAttribute("paddingTop").toIntOrNull() ?: 0,
+                paddingBottom = component.getStringAttribute("paddingBottom").toIntOrNull() ?: 0,
+            )
+    }
+}

--- a/core/src/commonMain/kotlin/org/sacada/core/blueprint/TopBarBlueprint.kt
+++ b/core/src/commonMain/kotlin/org/sacada/core/blueprint/TopBarBlueprint.kt
@@ -1,0 +1,46 @@
+package org.sacada.core.blueprint
+
+import org.sacada.core.model.ViewComponent
+import org.sacada.core.util.getStringAttribute
+
+/**
+ * Blueprint for a TopBar component with resolved attributes.
+ */
+data class TopBarBlueprint(
+    override val id: String,
+    val variant: String,
+    val paddingLeft: Int,
+    val paddingRight: Int,
+    val paddingTop: Int,
+    val paddingBottom: Int,
+    val title: String,
+    val scrollBehavior: String?,
+    val navigationIcon: ViewComponent?,
+    val actions: List<ViewComponent>
+) : Blueprint {
+    companion object {
+        fun from(component: ViewComponent): TopBarBlueprint {
+            val variant = component.getStringAttribute("topBarType")
+            val paddingLeft = component.getStringAttribute("paddingLeft").toIntOrNull() ?: 0
+            val paddingRight = component.getStringAttribute("paddingRight").toIntOrNull() ?: 0
+            val paddingTop = component.getStringAttribute("paddingTop").toIntOrNull() ?: 0
+            val paddingBottom = component.getStringAttribute("paddingBottom").toIntOrNull() ?: 0
+            val title = component.getStringAttribute("title")
+            val scrollBehavior = component.getStringAttribute("scrollBehavior")
+            val navigationIcon = component.children.find { it.type == "navigationIcon" }
+            val actions = component.children.filter { it.type == "Action" }
+            return TopBarBlueprint(
+                id = component.id,
+                variant = variant,
+                paddingLeft = paddingLeft,
+                paddingRight = paddingRight,
+                paddingTop = paddingTop,
+                paddingBottom = paddingBottom,
+                title = title,
+                scrollBehavior = scrollBehavior,
+                navigationIcon = navigationIcon,
+                actions = actions
+            )
+        }
+    }
+}

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/Component.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/Component.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
-import org.sacada.core.model.ViewComponent
+import org.sacada.core.blueprint.Blueprint
 import org.sacada.figma2sdui.data.nodes.BaseComponent
 import org.sacada.figma2sdui.data.nodes.properties.root.RootComponentDescription
 
@@ -12,7 +12,7 @@ interface Component {
     interface Renderer {
         @Composable
         fun Render(
-            component: ViewComponent,
+            blueprint: Blueprint,
             modifier: Modifier? = null,
         )
     }

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/ComponentRegistry.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/ComponentRegistry.kt
@@ -32,6 +32,13 @@ import org.sacada.data.ui.components.textField.TextFieldGenerator
 import org.sacada.data.ui.components.textField.TextFieldRenderer
 import org.sacada.data.ui.components.topBar.TopBarGenerator
 import org.sacada.data.ui.components.topBar.TopBarRenderer
+import org.sacada.core.blueprint.Blueprint
+import org.sacada.core.blueprint.BoxBlueprint
+import org.sacada.core.blueprint.ButtonBlueprint
+import org.sacada.core.blueprint.GenericBlueprint
+import org.sacada.core.blueprint.TextBlueprint
+import org.sacada.core.blueprint.TopBarBlueprint
+import org.sacada.core.model.ViewComponent
 
 object ComponentRegistry {
     fun getRenderer(type: String): Renderer =
@@ -72,5 +79,14 @@ object ComponentRegistry {
             ComponentType.Text -> TextGenerator
             ComponentType.TextField -> TextFieldGenerator
             ComponentType.TopBar -> TopBarGenerator
+        }
+
+    fun createBlueprint(component: ViewComponent): Blueprint =
+        when (ComponentType.fromType(component.type)) {
+            ComponentType.Box -> BoxBlueprint.from(component)
+            ComponentType.Button -> ButtonBlueprint.from(component)
+            ComponentType.Text -> TextBlueprint.from(component)
+            ComponentType.TopBar -> TopBarBlueprint.from(component)
+            else -> GenericBlueprint(component.id, component)
         }
 }

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/RenderComponent.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/RenderComponent.kt
@@ -3,6 +3,7 @@ package org.sacada.data.ui.components
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import org.sacada.core.blueprint.Blueprint
 import org.sacada.core.model.ViewComponent
 
 @Composable
@@ -11,8 +12,9 @@ fun RenderComponent(
     modifier: Modifier? = null,
 ) {
     val renderer = ComponentRegistry.getRenderer(component.type)
+    val blueprint = ComponentRegistry.createBlueprint(component)
 
-    renderer.Render(component, modifier)
+    renderer.Render(blueprint, modifier)
 }
 
 @Composable

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/bottomBar/BottomBarRenderer.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/bottomBar/BottomBarRenderer.kt
@@ -9,6 +9,8 @@ import androidx.compose.ui.Modifier
 import kotlinx.serialization.json.JsonPrimitive
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.sacada.annotation.RegisterComponent
+import org.sacada.core.blueprint.Blueprint
+import org.sacada.core.blueprint.GenericBlueprint
 import org.sacada.core.model.ViewComponent
 import org.sacada.data.ui.components.Component
 import org.sacada.data.ui.components.RenderComponent
@@ -18,11 +20,11 @@ import org.sacada.data.util.createActions
 object BottomBarRenderer : Component.Renderer {
     @Composable
     override fun Render(
-        component: ViewComponent,
+        blueprint: Blueprint,
         modifier: Modifier?,
     ) {
-        val fabComponent =
-            remember { component.children.find { it.type == "FloatingActionButton" } }
+        val component = (blueprint as? GenericBlueprint)?.component ?: return
+        val fabComponent = remember { component.children.find { it.type == "FloatingActionButton" } }
         val actions = component.createActions()
         val floatingActionButton = createFloatingActionButtonComposable(fabComponent)
 
@@ -70,5 +72,5 @@ fun PreviewRenderBottomBar() {
                     ),
                 ),
         )
-    BottomBarRenderer.Render(component = sampleComponent)
+    BottomBarRenderer.Render(GenericBlueprint(sampleComponent.id, sampleComponent))
 }

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/box/BoxRenderer.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/box/BoxRenderer.kt
@@ -2,6 +2,7 @@ package org.sacada.data.ui.components.box
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -11,26 +12,32 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.sacada.annotation.RegisterComponent
-import org.sacada.core.model.ViewComponent
-import org.sacada.core.util.getStringAttribute
+import org.sacada.core.blueprint.Blueprint
+import org.sacada.core.blueprint.BoxBlueprint
 import org.sacada.data.navigation.LocalNavigator
 import org.sacada.data.ui.components.Component
 import org.sacada.data.ui.components.RenderComponent
-import org.sacada.data.util.getPadding
-import org.sacada.data.util.performAction
 
 @RegisterComponent
 object BoxRenderer : Component.Renderer {
     @Composable
     override fun Render(
-        component: ViewComponent,
+        blueprint: Blueprint,
         modifier: Modifier?,
     ) {
+        blueprint as BoxBlueprint
         val navController = LocalNavigator.current
 
-        val padding = remember { component.getPadding() }
-        val height = component.getStringAttribute("height").toFloatOrNull()?.dp ?: 0.dp
-        val width = component.getStringAttribute("width").toFloatOrNull()?.dp ?: 0.dp
+        val padding = remember {
+            PaddingValues(
+                start = blueprint.paddingLeft.dp,
+                end = blueprint.paddingRight.dp,
+                top = blueprint.paddingTop.dp,
+                bottom = blueprint.paddingBottom.dp,
+            )
+        }
+        val height = blueprint.height.dp
+        val width = blueprint.width.dp
 
         Box(
             contentAlignment = Alignment.Center,
@@ -40,10 +47,16 @@ object BoxRenderer : Component.Renderer {
                     .height(height)
                     .padding(padding)
                     .clickable {
-                        component.performAction(navController)
+                        when (blueprint.action?.type) {
+                            "NAVIGATE" ->
+                                blueprint.action.destination?.let {
+                                    navController.navigate("screen/$it")
+                                }
+                            "BACK" -> navController.popBackStack()
+                        }
                     },
         ) {
-            component.children.forEach { child ->
+            blueprint.children.forEach { child ->
                 RenderComponent(child)
             }
         }

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/button/ButtonRenderer.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/button/ButtonRenderer.kt
@@ -7,25 +7,32 @@ import androidx.compose.ui.Modifier
 import kotlinx.serialization.json.JsonPrimitive
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.sacada.annotation.RegisterComponent
-import org.sacada.core.model.ViewComponent
+import org.sacada.core.blueprint.ButtonBlueprint
+import org.sacada.core.blueprint.Blueprint
 import org.sacada.data.navigation.LocalNavigator
 import org.sacada.data.ui.components.Component
 import org.sacada.data.ui.components.RenderComponent
-import org.sacada.data.util.performAction
 
 @RegisterComponent
 object ButtonRenderer : Component.Renderer {
     @Composable
     override fun Render(
-        component: ViewComponent,
+        blueprint: Blueprint,
         modifier: Modifier?,
     ) {
+        blueprint as ButtonBlueprint
         val navController = LocalNavigator.current
 
         Button(onClick = {
-            component.performAction(navController)
+            when (blueprint.action?.type) {
+                "NAVIGATE" ->
+                    blueprint.action.destination?.let {
+                        navController.navigate("screen/$it")
+                    }
+                "BACK" -> navController.popBackStack()
+            }
         }) {
-            component.children.forEach { child ->
+            blueprint.children.forEach { child ->
                 RenderComponent(child)
             }
         }
@@ -48,6 +55,6 @@ fun PreviewRenderButton_Varied() {
         )
 
     MaterialTheme {
-        ButtonRenderer.Render(component = sampleComponent)
+        ButtonRenderer.Render(ButtonBlueprint.from(sampleComponent))
     }
 }

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/checkbox/CheckboxRenderer.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/checkbox/CheckboxRenderer.kt
@@ -14,7 +14,8 @@ import androidx.compose.ui.unit.dp
 import kotlinx.serialization.json.JsonPrimitive
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.sacada.annotation.RegisterComponent
-import org.sacada.core.model.ViewComponent
+import org.sacada.core.blueprint.Blueprint
+import org.sacada.core.blueprint.GenericBlueprint
 import org.sacada.core.util.getStringAttribute
 import org.sacada.data.ui.components.Component
 
@@ -22,9 +23,10 @@ import org.sacada.data.ui.components.Component
 object CheckboxRenderer : Component.Renderer {
     @Composable
     override fun Render(
-        component: ViewComponent,
+        blueprint: Blueprint,
         modifier: Modifier?,
     ) {
+        val component = (blueprint as? GenericBlueprint)?.component ?: return
         val isChecked = rememberSaveable { mutableStateOf(false) }
         val labelText = component.getStringAttribute("label")
 
@@ -52,5 +54,5 @@ fun PreviewRenderCheckbox() {
                     "label" to JsonPrimitive("Accept Terms and Conditions"),
                 ),
         )
-    CheckboxRenderer.Render(component = sampleComponent)
+    CheckboxRenderer.Render(GenericBlueprint(sampleComponent.id, sampleComponent))
 }

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/column/ColumnRenderer.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/column/ColumnRenderer.kt
@@ -12,6 +12,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.sacada.annotation.RegisterComponent
+import org.sacada.core.blueprint.Blueprint
+import org.sacada.core.blueprint.GenericBlueprint
 import org.sacada.core.model.ViewComponent
 import org.sacada.core.util.getStringAttribute
 import org.sacada.data.ui.components.Component
@@ -26,9 +28,10 @@ import org.sacada.data.util.resolveVerticalArrangement
 object ColumnRenderer : Component.Renderer {
     @Composable
     override fun Render(
-        component: ViewComponent,
+        blueprint: Blueprint,
         modifier: Modifier?,
     ) {
+        val component = (blueprint as? GenericBlueprint)?.component ?: return
         val horizontalAlignment = component.resolveHorizontalAlignment()
         val verticalAlignment = component.resolveVerticalAlignment()
         val verticalArrangement = component.resolveVerticalArrangement(verticalAlignment)
@@ -124,6 +127,6 @@ fun PreviewRenderColumn_Varied() {
     """.parseJson()
 
     MaterialTheme {
-        ColumnRenderer.Render(component = sampleComponent)
+        ColumnRenderer.Render(GenericBlueprint(sampleComponent.id, sampleComponent))
     }
 }

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/floatingActionButton/FloatingActionButtonRenderer.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/floatingActionButton/FloatingActionButtonRenderer.kt
@@ -5,6 +5,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import org.sacada.annotation.RegisterComponent
+import org.sacada.core.blueprint.Blueprint
+import org.sacada.core.blueprint.GenericBlueprint
 import org.sacada.core.model.ViewComponent
 import org.sacada.core.util.getStringAttribute
 import org.sacada.data.ui.components.Component
@@ -19,9 +21,10 @@ import org.sacada.data.util.performAction
 object FloatingActionButtonRenderer : Component.Renderer {
     @Composable
     override fun Render(
-        component: ViewComponent,
+        blueprint: Blueprint,
         modifier: Modifier?,
     ) {
+        val component = (blueprint as? GenericBlueprint)?.component ?: return
         val navController = LocalNavigator.current
 //        val viewModel = LocalScreenViewModel.current
 //        val allComponentsValid by viewModel.areAllComponentsValid.collectAsState()
@@ -57,5 +60,5 @@ fun PreviewRenderFloatingActionButton() {
                     "contentDescription" to JsonPrimitive("Add"),
                 ),
         )
-    FloatingActionButtonRenderer.Render(component = sampleComponent)
+    FloatingActionButtonRenderer.Render(GenericBlueprint(sampleComponent.id, sampleComponent))
 }

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/icon/IconRenderer.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/icon/IconRenderer.kt
@@ -7,7 +7,8 @@ import androidx.compose.ui.Modifier
 import kotlinx.serialization.json.JsonPrimitive
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.sacada.annotation.RegisterComponent
-import org.sacada.core.model.ViewComponent
+import org.sacada.core.blueprint.Blueprint
+import org.sacada.core.blueprint.GenericBlueprint
 import org.sacada.core.util.getStringAttribute
 import org.sacada.data.ui.components.Component
 import org.sacada.data.util.getIconResource
@@ -16,9 +17,10 @@ import org.sacada.data.util.getIconResource
 object IconRenderer : Component.Renderer {
     @Composable
     override fun Render(
-        component: ViewComponent,
+        blueprint: Blueprint,
         modifier: Modifier?,
     ) {
+        val component = (blueprint as? GenericBlueprint)?.component ?: return
         val iconName = component.getStringAttribute("iconName")
         val contentDescription = component.getStringAttribute("contentDescription")
 
@@ -46,5 +48,5 @@ fun PreviewRenderIcon() {
                 ),
         )
 
-    IconRenderer.Render(component = testComponent)
+    IconRenderer.Render(GenericBlueprint(testComponent.id, testComponent))
 }

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/iconButton/IconButtonRenderer.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/iconButton/IconButtonRenderer.kt
@@ -7,7 +7,8 @@ import androidx.compose.ui.Modifier
 import kotlinx.serialization.json.JsonPrimitive
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.sacada.annotation.RegisterComponent
-import org.sacada.core.model.ViewComponent
+import org.sacada.core.blueprint.Blueprint
+import org.sacada.core.blueprint.GenericBlueprint
 import org.sacada.core.util.getStringAttribute
 import org.sacada.data.ui.components.Component
 import org.sacada.data.navigation.LocalNavigator
@@ -18,9 +19,10 @@ import org.sacada.data.util.performAction
 object IconButtonRenderer : Component.Renderer {
     @Composable
     override fun Render(
-        component: ViewComponent,
+        blueprint: Blueprint,
         modifier: Modifier?,
     ) {
+        val component = (blueprint as? GenericBlueprint)?.component ?: return
         val navController = LocalNavigator.current
 
         val iconName = component.getStringAttribute("iconName")
@@ -52,5 +54,5 @@ fun PreviewRenderIconButton() {
                 ),
         )
 
-    IconButtonRenderer.Render(component = testComponent)
+    IconButtonRenderer.Render(GenericBlueprint(testComponent.id, testComponent))
 }

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/image/ImageRenderer.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/image/ImageRenderer.kt
@@ -4,7 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 // import coil.compose.rememberAsyncImagePainter
 import org.sacada.annotation.RegisterComponent
-import org.sacada.core.model.ViewComponent
+import org.sacada.core.blueprint.Blueprint
+import org.sacada.core.blueprint.GenericBlueprint
 import org.sacada.core.util.getStringAttribute
 import org.sacada.data.ui.components.Component
 
@@ -12,9 +13,10 @@ import org.sacada.data.ui.components.Component
 object ImageRenderer : Component.Renderer {
     @Composable
     override fun Render(
-        component: ViewComponent,
+        blueprint: Blueprint,
         modifier: Modifier?,
     ) {
+        val component = (blueprint as? GenericBlueprint)?.component ?: return
         val imageUrl = component.getStringAttribute("imageUrl")
         val contentDescription = component.getStringAttribute("contentDescription")
 

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/list/ListRenderer.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/list/ListRenderer.kt
@@ -7,7 +7,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.sacada.annotation.RegisterComponent
-import org.sacada.core.model.ViewComponent
+import org.sacada.core.blueprint.Blueprint
+import org.sacada.core.blueprint.GenericBlueprint
 import org.sacada.core.util.getStringAttribute
 import org.sacada.data.ui.components.Component
 import org.sacada.data.ui.components.RenderComponent
@@ -16,9 +17,10 @@ import org.sacada.data.ui.components.RenderComponent
 object ListRenderer : Component.Renderer {
     @Composable
     override fun Render(
-        component: ViewComponent,
+        blueprint: Blueprint,
         modifier: Modifier?
     ) {
+        val component = (blueprint as? GenericBlueprint)?.component ?: return
         val itemSpacing = component.getStringAttribute("itemSpacing").toIntOrNull()?.dp ?: 0.dp
         LazyColumn(
             verticalArrangement = Arrangement.spacedBy(itemSpacing),

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/listItem/ListItemRenderer.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/listItem/ListItemRenderer.kt
@@ -4,6 +4,8 @@ import androidx.compose.material3.ListItem
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import org.sacada.annotation.RegisterComponent
+import org.sacada.core.blueprint.Blueprint
+import org.sacada.core.blueprint.GenericBlueprint
 import org.sacada.core.model.ViewComponent
 import org.sacada.data.ui.components.Component
 import org.sacada.data.ui.components.RenderComponent
@@ -12,9 +14,10 @@ import org.sacada.data.ui.components.RenderComponent
 object ListItemRenderer : Component.Renderer {
     @Composable
     override fun Render(
-        component: ViewComponent,
+        blueprint: Blueprint,
         modifier: Modifier?
     ) {
+        val component = (blueprint as? GenericBlueprint)?.component ?: return
         val headline = component.children.getOrNull(0)
         val supporting = component.children.getOrNull(1)
 

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/row/RowRenderer.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/row/RowRenderer.kt
@@ -10,6 +10,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import org.sacada.annotation.RegisterComponent
+import org.sacada.core.blueprint.Blueprint
+import org.sacada.core.blueprint.GenericBlueprint
 import org.sacada.core.model.ViewComponent
 import org.sacada.core.util.getStringAttribute
 import org.sacada.data.ui.components.Component
@@ -22,9 +24,10 @@ import org.sacada.data.util.resolveVerticalAlignment
 object RowRenderer : Component.Renderer {
     @Composable
     override fun Render(
-        component: ViewComponent,
+        blueprint: Blueprint,
         modifier: Modifier?,
     ) {
+        val component = (blueprint as? GenericBlueprint)?.component ?: return
         val horizontalArrangement = component.resolveHorizontalArrangement()
         val verticalAlignment = component.resolveVerticalAlignment()
 

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/switch/SwitchRenderer.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/switch/SwitchRenderer.kt
@@ -11,7 +11,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.sacada.annotation.RegisterComponent
-import org.sacada.core.model.ViewComponent
+import org.sacada.core.blueprint.Blueprint
+import org.sacada.core.blueprint.GenericBlueprint
 import org.sacada.core.util.getStringAttribute
 import org.sacada.data.ui.components.Component
 
@@ -19,9 +20,10 @@ import org.sacada.data.ui.components.Component
 object SwitchRenderer : Component.Renderer {
     @Composable
     override fun Render(
-        component: ViewComponent,
+        blueprint: Blueprint,
         modifier: Modifier?
     ) {
+        val component = (blueprint as? GenericBlueprint)?.component ?: return
         val isChecked = rememberSaveable { mutableStateOf(false) }
         val label = component.getStringAttribute("label")
 

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/text/TextRenderer.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/text/TextRenderer.kt
@@ -7,27 +7,49 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import org.sacada.annotation.RegisterComponent
+import org.sacada.core.blueprint.Blueprint
+import org.sacada.core.blueprint.TextBlueprint
 import org.sacada.core.model.ViewComponent
-import org.sacada.core.util.getStringAttribute
 import org.sacada.data.ui.components.Component
-import org.sacada.data.util.getPadding
-import org.sacada.data.util.getTextStyle
 import org.sacada.data.util.parseJson
 
 @RegisterComponent
 object TextRenderer : Component.Renderer {
     @Composable
     override fun Render(
-        component: ViewComponent,
+        blueprint: Blueprint,
         modifier: Modifier?,
     ) {
-        val textStyle = component.getTextStyle()
-        val padding = component.getPadding()
+        blueprint as TextBlueprint
+        val textStyle = when (blueprint.styleType) {
+            "displayLarge" -> MaterialTheme.typography.displayLarge
+            "displayMedium" -> MaterialTheme.typography.displayMedium
+            "displaySmall" -> MaterialTheme.typography.displaySmall
+            "headlineLarge" -> MaterialTheme.typography.headlineLarge
+            "headlineMedium" -> MaterialTheme.typography.headlineMedium
+            "headlineSmall" -> MaterialTheme.typography.headlineSmall
+            "titleLarge" -> MaterialTheme.typography.titleLarge
+            "titleMedium" -> MaterialTheme.typography.titleMedium
+            "titleSmall" -> MaterialTheme.typography.titleSmall
+            "bodyLarge" -> MaterialTheme.typography.bodyLarge
+            "bodyMedium" -> MaterialTheme.typography.bodyMedium
+            "bodySmall" -> MaterialTheme.typography.bodySmall
+            "labelLarge" -> MaterialTheme.typography.labelLarge
+            "labelMedium" -> MaterialTheme.typography.labelMedium
+            "labelSmall" -> MaterialTheme.typography.labelSmall
+            else -> MaterialTheme.typography.bodyMedium
+        }
+        val paddingModifier = Modifier.padding(
+            start = blueprint.paddingLeft.dp,
+            end = blueprint.paddingRight.dp,
+            top = blueprint.paddingTop.dp,
+            bottom = blueprint.paddingBottom.dp,
+        )
 
         Text(
-            text = component.getStringAttribute("content"),
+            text = blueprint.content,
             style = textStyle,
-            modifier = Modifier.padding(padding),
+            modifier = paddingModifier,
             textAlign = TextAlign.Center,
         )
     }
@@ -51,6 +73,6 @@ fun PreviewRenderText() {
     """.parseJson()
 
     MaterialTheme {
-        TextRenderer.Render(component = testComponent)
+        TextRenderer.Render(TextBlueprint.from(testComponent))
     }
 }

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/textField/TextFieldRenderer.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/textField/TextFieldRenderer.kt
@@ -14,6 +14,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import org.sacada.annotation.RegisterComponent
+import org.sacada.core.blueprint.Blueprint
+import org.sacada.core.blueprint.GenericBlueprint
 import org.sacada.core.model.ViewComponent
 import org.sacada.core.util.getBooleanAttribute
 import org.sacada.core.util.getStringAttribute
@@ -26,10 +28,11 @@ import org.sacada.data.util.getPadding
 object TextFieldRenderer : Component.Renderer {
     @Composable
     override fun Render(
-        component: ViewComponent,
+        blueprint: Blueprint,
         modifier: Modifier?,
     ) {
-//        val viewModel = LocalScreenViewModel.current
+        val component = (blueprint as? GenericBlueprint)?.component ?: return
+        //        val viewModel = LocalScreenViewModel.current
         val textValue = remember { mutableStateOf("") }
         val isValid = remember { mutableStateOf(component.isValid("")) }
 

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/components/topBar/TopBarRenderer.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/components/topBar/TopBarRenderer.kt
@@ -22,31 +22,32 @@ import androidx.compose.ui.unit.dp
 import kotlinx.serialization.json.JsonPrimitive
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.sacada.annotation.RegisterComponent
+import org.sacada.core.blueprint.Blueprint
+import org.sacada.core.blueprint.TopBarBlueprint
 import org.sacada.core.model.ViewComponent
-import org.sacada.core.util.getStringAttribute
 import org.sacada.data.ui.components.Component
 import org.sacada.data.ui.components.box.BoxRenderer
-import org.sacada.data.util.createActions
 
 @RegisterComponent
 object TopBarRenderer : Component.Renderer {
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     override fun Render(
-        component: ViewComponent,
+        blueprint: Blueprint,
         modifier: Modifier?,
     ) {
-        val scrollBehavior = resolveScrollBehavior(component.getStringAttribute("scrollBehavior"))
-        val appBar = remember { resolveAppBarType(component.getStringAttribute("topBarType")) }
+        blueprint as TopBarBlueprint
+        val scrollBehavior = resolveScrollBehavior(blueprint.scrollBehavior)
+        val appBar = remember { resolveAppBarType(blueprint.variant) }
 
-        val title = createTitleComposable(component.getStringAttribute("title"))
-        val navigationIcon = createNavigationIconComposable(component)
-        val actions = component.createActions()
+        val title = createTitleComposable(blueprint.title)
+        val navigationIcon = createNavigationIconComposable(blueprint.navigationIcon)
+        val actions = createActionsFromChildren(blueprint.actions)
 
-        val paddingLeft = component.getStringAttribute("paddingLeft").toIntOrNull() ?: 0
-        val paddingRight = component.getStringAttribute("paddingRight").toIntOrNull() ?: 0
-        val paddingTop = component.getStringAttribute("paddingTop").toIntOrNull() ?: 0
-        val paddingBottom = component.getStringAttribute("paddingBottom").toIntOrNull() ?: 0
+        val paddingLeft = blueprint.paddingLeft
+        val paddingRight = blueprint.paddingRight
+        val paddingTop = blueprint.paddingTop
+        val paddingBottom = blueprint.paddingBottom
 
         val paddingModifier =
             Modifier.padding(
@@ -162,8 +163,16 @@ private fun createTitleComposable(barTitle: String): @Composable () -> Unit =
 @Composable
 private fun createNavigationIconComposable(component: ViewComponent): @Composable () -> Unit =
     {
-        component.children.find { it.type == "navigationIcon" }?.let {
+        component.let {
             BoxRenderer.Render(it)
+        }
+    }
+
+@Composable
+private fun createActionsFromChildren(children: List<ViewComponent>): @Composable RowScope.() -> Unit =
+    {
+        children.forEach { actionComponent ->
+            BoxRenderer.Render(actionComponent)
         }
     }
 
@@ -196,5 +205,5 @@ fun PreviewRenderTopBar() {
                     ),
                 ),
         )
-    TopBarRenderer.Render(component = sampleComponent)
+    TopBarRenderer.Render(TopBarBlueprint.from(sampleComponent))
 }

--- a/data/src/commonMain/kotlin/org/sacada/data/ui/screen/RenderScreen.kt
+++ b/data/src/commonMain/kotlin/org/sacada/data/ui/screen/RenderScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import org.sacada.core.model.ViewScreen
+import org.sacada.core.blueprint.TopBarBlueprint
+import org.sacada.data.ui.components.ComponentRegistry
 import org.sacada.data.ui.components.RenderComponent
 import org.sacada.data.ui.components.bottomBar.BottomBarRenderer
 import org.sacada.data.ui.components.topBar.TopBarRenderer
@@ -21,10 +23,10 @@ fun RenderScreen(screen: ViewScreen) {
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         topBar = {
-            screen.topBar?.let { TopBarRenderer.Render(it) }
+            screen.topBar?.let { TopBarRenderer.Render(TopBarBlueprint.from(it)) }
         },
         bottomBar = {
-            screen.bottomBar?.let { BottomBarRenderer.Render(it) }
+            screen.bottomBar?.let { BottomBarRenderer.Render(ComponentRegistry.createBlueprint(it)) }
         },
     ) { innerPadding ->
         Column(


### PR DESCRIPTION
## Summary
- add `Blueprint` sealed interface and specific blueprints for top bar, text, button and box
- generate blueprints from `ViewComponent` in `ComponentRegistry`
- refactor renderers to consume blueprints
- update `RenderComponent` and `RenderScreen` to use blueprints
- simplify compose-generator to call `RenderScreen`

## Testing
- `./gradlew assemble` *(fails: can not find property : FIGMA_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_687a8aad1384832f8acf41d086d76004